### PR TITLE
Convert fir3eye1/cicd to GitHub Actions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,17 @@
+name: fir3eye1/cicd
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  build_job:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "hello from gitlab cicd"


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/fir3eye1/cicd) :tada: